### PR TITLE
Add WithDeadline and WithTimeout context functions

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -1,6 +1,7 @@
 package abtime
 
 import (
+	"context"
 	"time"
 )
 
@@ -29,4 +30,7 @@ type AbstractTime interface {
 	NewTicker(time.Duration, int) Ticker
 	AfterFunc(time.Duration, func(), int) Timer
 	NewTimer(time.Duration, int) Timer
+
+	WithDeadline(context.Context, time.Time, int) (context.Context, context.CancelFunc)
+	WithTimeout(context.Context, time.Duration, int) (context.Context, context.CancelFunc)
 }

--- a/manual.go
+++ b/manual.go
@@ -7,6 +7,7 @@ package abtime
 // test suite. Plus that's just a weird binding that invites problems.
 
 import (
+	"context"
 	"sync"
 	"time"
 )
@@ -356,4 +357,80 @@ func (mt *ManualTime) NewTimer(d time.Duration, id int) Timer {
 	tt := &timerTrigger{c: make(chan time.Time), initialNow: mt.now, duration: d}
 	go mt.register(id, tt)
 	return tt
+}
+
+type contextTrigger struct {
+	context.Context
+	deadline time.Time
+	closed   bool
+	done     chan struct{}
+	err      error
+	mu       sync.Mutex
+}
+
+func (ct *contextTrigger) Deadline() (time.Time, bool) {
+	return ct.deadline, true
+}
+
+func (ct *contextTrigger) Done() <-chan struct{} {
+	return ct.done
+}
+
+func (ct *contextTrigger) Err() error {
+	ct.mu.Lock()
+	defer ct.mu.Unlock()
+	return ct.err
+}
+
+func (ct *contextTrigger) Value(key interface{}) interface{} {
+	return ct.Context.Value(key)
+}
+
+func (ct *contextTrigger) cancel(err error) {
+	ct.mu.Lock()
+	defer ct.mu.Unlock()
+	if !ct.closed {
+		close(ct.done)
+		ct.closed = true
+		ct.err = err
+	}
+}
+
+func (ct *contextTrigger) trigger(_ *ManualTime) bool {
+	ct.cancel(context.DeadlineExceeded)
+	return true
+}
+
+// WithDeadline is a valid Context that is meant to drop in over a regular
+// context.WithDeadline invocation. Instead of being canceled when reaching an
+// actual deadline the context is canceled either by Trigger or by the returned
+// CancelFunc.
+func (mt *ManualTime) WithDeadline(parent context.Context, deadline time.Time, id int) (context.Context, context.CancelFunc) {
+	if parent == nil {
+		panic("cannot create context from nil parent")
+	}
+	ct := &contextTrigger{
+		Context:  parent,
+		deadline: deadline,
+		done:     make(chan struct{}),
+	}
+	cancelF := func() {
+		ct.cancel(context.Canceled)
+	}
+	mt.register(id, ct)
+	go func() {
+		select {
+		case <-parent.Done():
+			ct.cancel(parent.Err())
+		case <-ct.Done():
+			// do nothing
+		}
+	}()
+	return ct, context.CancelFunc(cancelF)
+}
+
+// WithTimeout is equivalent to WithDeadline invoked on a deadline equal to the
+// current time plus the timeout.
+func (mt *ManualTime) WithTimeout(parent context.Context, timeout time.Duration, id int) (context.Context, context.CancelFunc) {
+	return mt.WithDeadline(parent, mt.Now().Add(timeout), id)
 }

--- a/manual_test.go
+++ b/manual_test.go
@@ -1,6 +1,8 @@
 package abtime
 
 import (
+	"context"
+	"errors"
 	"testing"
 	"time"
 )
@@ -12,6 +14,8 @@ const (
 	tickID2
 	afterFuncID
 	timerID
+	contextID
+	childContextID
 )
 
 func TestAfter(t *testing.T) {
@@ -260,4 +264,138 @@ func TestMultipleTimerCreation(t *testing.T) {
 	go c.Trigger(timerID)
 	<-timer2.Channel()
 
+}
+
+func TestContextCancel(t *testing.T) {
+	mt := NewManual()
+
+	ctx, cancelF := mt.WithTimeout(context.Background(), time.Minute, contextID)
+
+	select {
+	case <-ctx.Done():
+		t.Fatal("context done channel already closed")
+	default:
+	}
+
+	if ctx.Err() != nil {
+		t.Fatal("context error is not nil")
+	}
+
+	cancelF()
+
+	select {
+	case <-ctx.Done():
+	default:
+		t.Fatal("context done channel open when it should be closed")
+	}
+
+	if ctx.Err() == nil || !errors.Is(ctx.Err(), context.Canceled) {
+		t.Fatal("context error is not context.Canceled")
+	}
+}
+
+func TestContextTrigger(t *testing.T) {
+	mt := NewManual()
+
+	ctx, cancelF := mt.WithTimeout(context.Background(), time.Minute, contextID)
+
+	select {
+	case <-ctx.Done():
+		t.Fatal("context done channel already closed")
+	default:
+	}
+
+	if ctx.Err() != nil {
+		t.Fatal("context error is not nil")
+	}
+
+	mt.Trigger(contextID)
+
+	select {
+	case <-ctx.Done():
+	default:
+		t.Fatal("context done channel open when it should be closed")
+	}
+
+	if ctx.Err() == nil || !errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		t.Fatal("context error is not context.DeadlineExceeded")
+	}
+
+	cancelF()
+
+	if ctx.Err() == nil || !errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		t.Fatal("context error is not context.DeadlineExceeded")
+	}
+}
+
+func TestContextNestedCancel(t *testing.T) {
+	mt := NewManual()
+
+	parent, parentCancel := context.WithCancel(context.Background())
+	child, childCancel := mt.WithTimeout(parent, time.Minute, contextID)
+
+	select {
+	case <-child.Done():
+		t.Fatal("context done channel already closed")
+	default:
+	}
+
+	if child.Err() != nil {
+		t.Fatal("context error is not nil")
+	}
+
+	parentCancel()
+
+	select {
+	case <-child.Done():
+	case <-time.After(50 * time.Microsecond):
+		t.Fatal("context done channel open when it should be closed")
+	}
+
+	if child.Err() == nil || !errors.Is(child.Err(), context.Canceled) {
+		t.Fatal("context error is not context.Canceled")
+	}
+
+	childCancel()
+}
+
+func TestContextNestedTimeout(t *testing.T) {
+	mt := NewManual()
+
+	parent, parentCancel := mt.WithTimeout(context.Background(), time.Minute, contextID)
+	child, childCancel := mt.WithTimeout(parent, time.Minute, childContextID)
+
+	select {
+	case <-child.Done():
+		t.Fatal("context done channel already closed")
+	default:
+	}
+
+	if child.Err() != nil {
+		t.Fatal("context error is not nil")
+	}
+
+	mt.Trigger(contextID)
+
+	select {
+	case <-child.Done():
+	case <-time.After(50 * time.Microsecond):
+		t.Fatal("context done channel open when it should be closed")
+	}
+
+	if child.Err() == nil || !errors.Is(child.Err(), context.DeadlineExceeded) {
+		t.Fatal("context error is not context.DeadlineExceeded")
+	}
+
+	childCancel()
+
+	if child.Err() == nil || !errors.Is(child.Err(), context.DeadlineExceeded) {
+		t.Fatal("context error is not context.DeadlineExceeded")
+	}
+
+	parentCancel()
+
+	if child.Err() == nil || !errors.Is(child.Err(), context.DeadlineExceeded) {
+		t.Fatal("context error is not context.DeadlineExceeded")
+	}
 }

--- a/realtime.go
+++ b/realtime.go
@@ -1,6 +1,7 @@
 package abtime
 
 import (
+	"context"
 	"time"
 )
 
@@ -81,4 +82,14 @@ func (tw tickerWrapper) Channel() <-chan time.Time {
 
 func (tw tickerWrapper) Reset(d time.Duration) {
 	tw.Ticker.Reset(d)
+}
+
+// WithDeadline wraps context's normal WithDeadline invocation.
+func (rt RealTime) WithDeadline(parent context.Context, deadline time.Time, _ int) (context.Context, context.CancelFunc) {
+	return context.WithDeadline(parent, deadline)
+}
+
+// WithTimeout wraps context's normal WithTimeout invocation.
+func (rt RealTime) WithTimeout(parent context.Context, timeout time.Duration, _ int) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(parent, timeout)
 }


### PR DESCRIPTION
Given the frequent use of Contexts over timers, etc., it may be helpful to have Contexts based on abtime.