### PR TITLE
Miscellaneous Fixes

### DIFF
--- a/manual.go
+++ b/manual.go
@@ -340,8 +340,9 @@ func (tt *timerTrigger) Stop() bool {
 	tt.Lock()
 	defer tt.Unlock()
 
+	ret := tt.stopped
 	tt.stopped = true
-	return true
+	return ret
 }
 
 func (tt *timerTrigger) Channel() <-chan time.Time {

--- a/manual.go
+++ b/manual.go
@@ -43,28 +43,13 @@ func (mt *ManualTime) register(id int, trig trigger) {
 
 	currentTriggerInfo, present := mt.triggers[id]
 	if !present {
-		ti := &triggerInfo{0, []trigger{trig}}
-		mt.triggers[id] = ti
-		currentTriggerInfo = ti
+		mt.triggers[id] = &triggerInfo{0, []trigger{trig}}
+		return
 	}
 
 	currentTriggerInfo.triggers = append(currentTriggerInfo.triggers, trig)
 
-	if currentTriggerInfo.count == 0 {
-		return
-	}
-
-	for currentTriggerInfo.count > 0 && len(currentTriggerInfo.triggers) > 0 {
-		toTrigger := currentTriggerInfo.triggers[0]
-		currentTriggerInfo.count--
-
-		discard := toTrigger.trigger(mt)
-
-		if discard {
-			currentTriggerInfo.triggers = currentTriggerInfo.triggers[1:]
-			continue
-		}
-	}
+	triggerAll(mt, currentTriggerInfo)
 }
 
 // NewManual returns a new ManualTime object, with the Now populated
@@ -77,6 +62,21 @@ func NewManual() *ManualTime {
 // time.Time you pass in.
 func NewManualAtTime(now time.Time) *ManualTime {
 	return &ManualTime{now: now, nows: []time.Time{}, triggers: make(map[int]*triggerInfo)}
+}
+
+// triggerAll triggers all registered triggers count times, discarding triggers
+// as requested.
+func triggerAll(mt *ManualTime, ti *triggerInfo) {
+	for ti.count > 0 && len(ti.triggers) > 0 {
+		keep := []trigger{}
+		for _, toTrigger := range ti.triggers {
+			if !toTrigger.trigger(mt) {
+				keep = append(keep, toTrigger)
+			}
+		}
+		ti.triggers = keep
+		ti.count--
+	}
 }
 
 // Trigger takes the given ids for time events, and causes them to "occur":
@@ -97,17 +97,10 @@ func (mt *ManualTime) Trigger(ids ...int) {
 			mt.triggers[id] = &triggerInfo{1, []trigger{}}
 			continue
 		}
-		if len(triggers.triggers) == 0 {
-			triggers.count++
-			continue
-		}
 
-		t := triggers.triggers[0]
-		discard := t.trigger(mt)
+		triggers.count++
 
-		if discard {
-			triggers.triggers = triggers.triggers[1:]
-		}
+		triggerAll(mt, triggers)
 	}
 }
 

--- a/manual_test.go
+++ b/manual_test.go
@@ -184,7 +184,7 @@ func TestTimer(t *testing.T) {
 
 	timer = at.NewTimer(time.Second, timerID)
 	timer.Reset(2 * time.Second)
-	if !timer.Stop() {
+	if timer.Stop() {
 		t.Fatal("Stopping the timer should have returned true")
 	}
 	at.Trigger(timerID)
@@ -203,18 +203,18 @@ func TestTimerResetRunsCorrectly(t *testing.T) {
 	timer := at.NewTimer(time.Second, timerID)
 
 	ret := timer.Stop()
-	if !ret {
-		t.Fatal("timer should be marked as running")
+	if ret {
+		t.Fatal("timer should return true to indicate Stop() stopped it")
 	}
 	ret = timer.Stop()
-	if ret {
-		t.Fatal("timer should be marked as not running")
+	if !ret {
+		t.Fatal("timer should return false to indicate Stop() didn't stop it")
 	}
 	timer.Reset(time.Second)
 	ret = timer.Stop()
-	if !ret {
+	if ret {
 		// This is where the bug would occur.
-		t.Fatal("timer should be marked as running again")
+		t.Fatal("timer should return true to indicate Stop() stopped it")
 	}
 }
 


### PR DESCRIPTION
Fixed bugs where:
ManualTime's Timer's Stop() function was returning false always instead of true when the timer was stopped by Stop().
register() registered the first trigger for an ID twice.

Changed behavior of register() and trigger() to propagate trigger events to each trigger count times instead of triggering each trigger one or more times depending on whether the trigger is discarded.